### PR TITLE
MUnit library in classpath

### DIFF
--- a/GlobalWeatherService/.classpath
+++ b/GlobalWeatherService/.classpath
@@ -10,5 +10,6 @@
 	<classpathentry kind="src" path="src/main/api"/>
 	<classpathentry kind="src" path="src/main/wsdl"/>
 	<classpathentry kind="src" path="src/test/munit"/>
+	<classpathentry kind="con" path="MUNIT_RUNTIME"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Added missing MUnit Runtime library to project classpath to fix the following error:
Description	Resource	Path	Location	Type
The project is missing MUnit libraries to run tests	get_city_by_country-test-suite.xml	/GlobalWeatherService/src/test/munit	Unknown	MUnit problem