### PR TITLE
Fixed reference to mule.env property in global.xml

### DIFF
--- a/GlobalWeatherService/src/main/app/global/global.xml
+++ b/GlobalWeatherService/src/main/app/global/global.xml
@@ -10,7 +10,7 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd">
 	<context:property-placeholder
-		location="properties/globalweather-${mule.envt}.properties" />
+		location="properties/globalweather-${mule.env}.properties" />
 	<http:listener-config name="weather-api-httpListenerConfig"
 		host="${http.host}" port="${http.port}" doc:name="HTTP Listener Configuration"
 		basePath="/v1" />


### PR DESCRIPTION
Replaced mule.envt with mule.env as defined in the properties file to fix the following exception:
ERROR 2018-12-07 14:40:23,561 [main] org.mule.module.launcher.application.DefaultMuleApplication: null
java.io.FileNotFoundException: class path resource [properties/globalweather-${mule.envt}.properties] cannot be opened because it does not exist