### PR TITLE
Fixed CityName payload output type in sf_get_weather_request

### DIFF
--- a/GlobalWeatherService/src/main/app/implementation/get_weather.xml
+++ b/GlobalWeatherService/src/main/app/implementation/get_weather.xml
@@ -27,7 +27,7 @@ flowVars.qpCountry= message.inboundProperties.'http.query.params'.country;]]></e
 ---
 {
 	ns0#GetWeather: {
-		ns0#CityName: inboundProperties."http.query.params".city as :number,
+		ns0#CityName: inboundProperties."http.query.params".city,
 		ns0#CountryName: inboundProperties."http.query.params".country
 	}
 }]]></dw:set-payload>


### PR DESCRIPTION
Removed type conversion for CityName in Transform Message connector of sf_get_weather_request as it is meant to be a string. Corresponding error message was:

ERROR 2018-12-07 14:54:52,516 [[GlobalWeatherService].weather-api-httpListenerConfig.worker.02] org.mule.exception.DefaultMessagingExceptionStrategy:
********************************************************************************
Message               : Exception while executing:
		ns0#CityName: inboundProperties."http.query.params".city as :number,
		              ^
Cannot coerce a :string to a :number, caused by :Cannot convert "Melbourne" to a number.
Payload               : {NullPayload}
Payload Type          : org.mule.transport.NullPayload
Element               : /get:\/weather:weather-api-config/processors/1/sf_get_weather_request/subprocessors/1 @ GlobalWeatherService:get_weather.xml:20 (Generate Request Message)
Element XML           : <dw:transform-message doc:name="Generate Request Message" metadata:id="aa019d34-59e0-49e7-899a-bcdca69f8aa9">
                        <dw:input-payload></dw:input-payload>
                        <dw:input-variable mimeType="application/java" variableName="qpCity"></dw:input-variable>
                        <dw:set-payload>%dw 1.0
%output application/xml
%namespace ns0 http://www.webserviceX.NET
---
{
	ns0#GetWeather: {
		ns0#CityName: inboundProperties."http.query.params".city as :number,
		ns0#CountryName: inboundProperties."http.query.params".country
	}
}</dw:set-payload>
                        </dw:transform-message>
--------------------------------------------------------------------------------
Root Exception stack trace:
com.mulesoft.weave.mule.exception.WeaveExecutionException: Exception while executing:
		ns0#CityName: inboundProperties."http.query.params".city as :number,