### PR TITLE
Implemented until-successful in get_weather flow

### DIFF
--- a/GlobalWeatherService/src/main/app/implementation/get_weather.xml
+++ b/GlobalWeatherService/src/main/app/implementation/get_weather.xml
@@ -35,8 +35,10 @@ flowVars.qpCountry= message.inboundProperties.'http.query.params'.country;]]></e
 		<logger
 			message="#[flowVars.LogMsg + &quot;\nRequest Message (Transformed): \n&quot; + payload]"
 			level="INFO" doc:name="Log Transform Request Message" />
-		<ws:consumer config-ref="WS_Consumer_Weather" operation="GetWeather"
-			doc:name="Invoke Global Weather Call" />
+        <until-successful maxRetries="5" synchronous="true" doc:name="Until Successful">
+            <ws:consumer config-ref="WS_Consumer_Weather" operation="GetWeather" doc:name="Invoke Global Weather Call"/>
+        </until-successful>
+
 
 		<logger
 			message="#[flowVars.LogMsg + &quot;\nResponse Message (RAW): \n&quot;+ message.payloadAs(java.lang.String)]"


### PR DESCRIPTION
Surrounded the WS Consumer connector with an Until-Successful connector as that seemed like the flakey part of the flow. Rest of the flow should not be retried as it would only lead to Validation Exceptions.